### PR TITLE
README: fix links under "how to use"

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ yarn add @projectstorm/react-diagrams-routing@next
 
 ## How to use
 
-Take a look at the [diagram demos](https://github.com/projectstorm/react-diagrams/tree/8fbd87df8c074e0263fd86a64b05a56687a631cf/packages/diagrams-demo-gallery/demos/README.md)
+Take a look at the [diagram demos](https://github.com/projectstorm/react-diagrams/tree/master/packages/diagrams-demo-gallery/demos)
 
 **or**
 
-Take a look at the [demo project](https://github.com/projectstorm/react-diagrams/tree/8fbd87df8c074e0263fd86a64b05a56687a631cf/packages/diagrams-demo-project/README.md) which contains an example for ES6 as well as Typescript
+Take a look at the [demo project](https://github.com/projectstorm/react-diagrams/tree/master/packages/diagrams-demo-project) which contains an example for ES6 as well as Typescript
 
 ## Run the demos
 


### PR DESCRIPTION

# Checklist

- [ ] The code has been run through pretty `yarn run pretty`
- [ ] The tests pass on CircleCI
- [ ] You have referenced the issue(s) or other PR(s) this fixes/relates-to
- [X] The PR Template has been filled out (see below)
- [X] Had a beer/coffee because you are awesome

## What?
README: fix links under "how to use"

## Why?
first link was broken, plus second was only to the readme for an old tree

## How?
links updated

## Feel good image:

(Add your own one below :])

![LOL](https://i.pinimg.com/originals/7f/1b/c3/7f1bc3fb2e123dd3255a85c04db22f19.jpg)


